### PR TITLE
Fix function name typo

### DIFF
--- a/release
+++ b/release
@@ -36,7 +36,7 @@ main() {
     exit 1
   fi
 
-  preauth_gpg_signature
+  preauth_pgp_signature
 
   git pull --ff-only origin master
 


### PR DESCRIPTION
Function was named `preauth_pgp_signature`, but was invoked as `preauth_gpg_signature`. Whoops! Easy one to miss.