### PR TITLE
Add Knex migration scripts

### DIFF
--- a/create-migration
+++ b/create-migration
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+main() {
+  name=${1:-""}
+
+  if [ "$name" == "" ]; then
+    echo "Usage: create-migration [migration-name]"
+    exit 1
+  fi
+
+  date_stamp=$(date "+%Y%m%d%H%M%S")
+
+  filename=migrations/$date_stamp'_'$name.js
+  cp migrations/_template $filename
+  echo 'Created '$filename
+
+  echo -n 'Open in '$EDITOR'? [y/n] '
+  read -n 1 should_edit
+
+  if [ "$should_edit" == "y" ]; then
+    $EDITOR $filename
+  fi
+}
+
+main "$@"

--- a/migrate-local
+++ b/migrate-local
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+echo 'Migrating local DB'
+$(npm bin)/knex migrate:latest
+
+echo 'Migrating local test DB'
+NODE_ENV=test $(npm bin)/knex migrate:latest

--- a/migrate-prod
+++ b/migrate-prod
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+main() {
+  app=${1:-""}
+
+  if [ "$app" == "" ]; then
+      echo "Usage: migrate-prod [heroku app name]"
+      exit 1
+  fi
+
+  if [[ $(git rev-parse --abbrev-ref HEAD) != "master" ]] ; then
+    echo 'Cannot run stg/prod migrations from a branch other than master'
+    exit 1
+  fi
+
+  if [[ $(git status --porcelain) != '' ]] ; then
+    echo 'Cannot migrate with uncommitted changes'
+    exit 1
+  fi
+
+  if [[ $(git cherry -v origin/master) != "" ]]; then
+    echo 'Cannot migrate with unpushed commits'
+    exit 1
+  fi
+
+  echo "Are you sure you want to migrate the PRODUCTION db?"
+  echo -n "Type PRODUCTION if you're sure: "
+  read RES
+
+  if [ "$RES" != "PRODUCTION" ]; then
+    echo "OK, not migrating"
+    exit 1
+  fi
+
+  DATABASE_URL=$(heroku config:get DATABASE_URL --app "$app"-prod)?ssl=true $(npm bin)/knex migrate:latest
+}
+
+main "$@"

--- a/migrate-stg
+++ b/migrate-stg
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+main() {
+  app=${1:-""}
+
+  if [ "$app" == "" ]; then
+    echo "Usage: migrate-stg [heroku app name]"
+    exit 1
+  fi
+
+  if [[ $(git rev-parse --abbrev-ref HEAD) != "master" ]] ; then
+    echo 'Cannot run stg/prod migrations from a branch other than master'
+    exit 1
+  fi
+
+  if [[ $(git status --porcelain) != '' ]] ; then
+    echo 'Cannot migrate with uncommitted changes'
+    exit 1
+  fi
+
+  if [[ $(git cherry -v origin/master) != "" ]]; then
+    echo 'Cannot migrate with unpushed commits'
+    exit 1
+  fi
+
+  if [[ "$1" != "--force" ]]; then
+    echo "Are you sure you want to migrate the STAGING db?"
+    echo -n "Type STAGING if you're sure: "
+    read RES
+
+    if [ "$RES" != "STAGING" ]; then
+      echo "OK, not migrating"
+      exit 1
+    fi
+  fi
+
+  DATABASE_URL=$(heroku config:get DATABASE_URL --app "$app"-stg)?ssl=true $(npm bin)/knex migrate:latest
+}
+
+main "$@"

--- a/rollback-local
+++ b/rollback-local
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+echo 'Rolling back local DB'
+$(npm bin)/knex migrate:rollback
+
+echo 'Rolling back local test DB'
+NODE_ENV=test $(npm bin)/knex migrate:rollback

--- a/rollback-prod
+++ b/rollback-prod
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+main() {
+  app=${1:-""}
+
+  if [ "$app" == "" ]; then
+    echo "Usage: rollback-prod [heroku app name]"
+    exit 1
+  fi
+
+  echo "Are you sure you want to ROLL BACK the PRODUCTION db? This is high risk and there are very few good reasons to ever need to do this. Type ROLLBACK if so:"
+  read RES
+
+  if [ "$RES" != "ROLLBACK" ]; then
+    echo "Not rolling back."
+    exit 1
+  fi
+
+  DATABASE_URL=$(heroku config:get DATABASE_URL --app "$app"-prod)?ssl=true $(npm bin)/knex migrate:rollback
+}
+
+main "$@"

--- a/rollback-stg
+++ b/rollback-stg
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+main() {
+  app=${1:-""}
+
+  if [ "$app" == "" ]; then
+    echo "Usage: rollback-stg [heroku app name]"
+    exit 1
+  fi
+
+  echo "Are you sure you want to ROLL BACK the STAGING db? This is high risk and there are very few good reasons to ever need to do this. Type ROLLBACK if so:"
+  read RES
+
+  if [ "$RES" != "ROLLBACK" ]; then
+    echo "Not rolling back."
+    exit 1
+  fi
+
+  DATABASE_URL=$(heroku config:get DATABASE_URL --app "$app"-stg)?ssl=true $(npm bin)/knex migrate:rollback
+}
+
+main "$@"


### PR DESCRIPTION
I dislike how you have to pass the first part of the name of the app to the migration/rollback scripts. Here are some ideas to get around that:

1. Each project will have a Make task that partially applies the app name so you can do `make migrate-prod` instead of `migrate-prod cala-api`?
2. Add an entry in `.env` that is the actual Heroku app names for `prod` and `stg` in each repo and look them up there in the migration scripts?