### PR TITLE
Match the validation script path to the migration script path

### DIFF
--- a/validate-migration
+++ b/validate-migration
@@ -16,12 +16,12 @@ db_url='postgres://localhost/cala-test'
 
 migrate() {
   # Swap this out for your own implementation if you're not using knex
-  DATABASE_URL=$db_url $(npm bin)/ts-node $(npm bin)/knex migrate:latest --knexfile src/knexfile.js
+  DATABASE_URL=$db_url $(npm bin)/knex migrate:latest --knexfile dist/knexfile.js
 }
 
 rollback() {
   # Swap this out for your own implementation if you're not using knex
-  DATABASE_URL=$db_url $(npm bin)/ts-node $(npm bin)/knex migrate:rollback --knexfile src/knexfile.js
+  DATABASE_URL=$db_url $(npm bin)/knex migrate:rollback --knexfile dist/knexfile.js
 }
 
 pre() {


### PR DESCRIPTION
We switched to migrating from the `dist/` directory, so the entry in the migrations database has the `js` file name, which would be different from what the script will find in the `src/` directory.