### PR TITLE
Only list .js files when getting latest migration

### DIFF
--- a/validate-deployment-readiness
+++ b/validate-deployment-readiness
@@ -46,8 +46,7 @@ main() {
   echo $c_yellow'Deployed hash: '$c_reset$deployed_hash
 
   latest_local_migration=$(
-    ls -Ar $migrations |\
-      grep -v _template |\
+    ls -Ar $migrations/*.js |\
       head -n 1 |\
       tr -d '\n'
   )


### PR DESCRIPTION
`dist/migrations` also contains `.js.map` files which means it will grab that file instead of the last script.

Not sure if this will fix the `SIGPIPE` issue that is keeping the validation script from completing since I couldn't think of a way to test this other than locally, but it wasn't getting that behavior on macOS.