### PR TITLE
Strip trailing paths from latest migration filename

### DIFF
--- a/validate-deployment-readiness
+++ b/validate-deployment-readiness
@@ -38,17 +38,19 @@ main() {
   esac
 
   deployed_hash=$(
-    curl -sA 'validate-deployment-readiness script' $status_url |\
-      egrep -o '"lastMigrationHash":"[^"]*"' |\
+    curl -sA 'validate-deployment-readiness script' $status_url |
+      egrep -o '"lastMigrationHash":"[^"]*"' |
       cut -d '"' -f 4
   )
 
   echo $c_yellow'Deployed hash: '$c_reset$deployed_hash
 
   latest_local_migration=$(
-    ls -Ar $migrations/*.js |\
-      head -n 1 |\
-      tr -d '\n'
+    ls -Ar $migrations/*.js | # List all migrations, descending order by name
+      head -n 1 |  # Take the first one
+      tr -d '\n' | # Remove trailing newline
+      awk -F / '{print $NF}' # Filter down to the last field after a '/' character,
+                             # e.g. foo/bar/x.js becomes x.js
   )
 
   local_hash=$(echo -n $latest_local_migration | shasum -a 256 | cut -d ' ' -f 1)


### PR DESCRIPTION
e.g. if you `validate-migration staging dist/migrations`, the "latest
file name" should be `201811111_latest.js` not `dist/migrations/20181111_latest.js`.

I'm not sure why these pipes were escaped before, I can't see a good
reason for it, so removed them (which makes it possible to add
comments).