### PR TITLE
Allow deployments in case of non-200 response status

### DIFF
--- a/validate-deployment-readiness
+++ b/validate-deployment-readiness
@@ -37,8 +37,18 @@ main() {
       ;;
   esac
 
+  # The HTTP response body, followed by the response code on a new line
+  response_and_status=$(curl -s -w "\n%{http_code}" -o - -A 'validate-deployment-readiness script' $status_url)
+  status=$(echo "$response_and_status" | tail -n 1)
+
+  if [[ $status != '200' ]] ; then
+    # Assume that the server has crashed, so the best option is to _allow_ deployment
+    echo $c_yellow'Warning: Bad response status ('$status')!'$c_reset
+    exit 0
+  fi
+
   deployed_hash=$(
-    curl -sA 'validate-deployment-readiness script' $status_url |
+    echo $response_and_status |
       egrep -o '"lastMigrationHash":"[^"]*"' |
       cut -d '"' -f 4
   )


### PR DESCRIPTION
Testing with the API:

```
$ ../bin/validate-deployment-readiness production dist/migrations
Deployed hash: 4a401d6223bfec4fb7687b93985e41c8ffe6b55d1c94eb98f2e61df2e1be94e7
Local hash: 3bdff9b6fdac2117fde09d243545302f45d38fca0440de9cf6a90cebb9f7ae03
Hash mismatch! Make sure to run migrations _before_ deploying. Aborting.

$ ../bin/validate-deployment-readiness staging dist/migrations
Warning: Bad response status (503)!
```