### PR TITLE
Allow deploy on invalid JSON

### DIFF
--- a/validate-deployment-readiness
+++ b/validate-deployment-readiness
@@ -44,7 +44,7 @@ async function main() {
     deployedHash = await getDeployedHash(target);
   } catch (error) {
     if (error instanceof HttpError) {
-      console.log(`${yellow}Warning: Bad response status. Skipping.${reset}`);
+      console.log(`${yellow}Warning: Bad response from server. Skipping.${reset}`);
       console.error(error);
       process.exit(0);
     } else {
@@ -87,7 +87,12 @@ function getDeployedHash(target) {
 
         res.on('data', d => response = response.concat(d));
         res.on('end', () => {
-          const responseJson = JSON.parse(response.join(''));
+          const responseString = response.join('');
+          try {
+            const responseJson = JSON.parse(responseString);
+          } catch (e) {
+            reject(new HttpError(`Server returned invalid JSON. Response: \n${responseString}`));
+          }
 
           if (responseJson.status === 'ok') {
             resolve(responseJson.lastMigrationHash);


### PR DESCRIPTION
Related to: https://github.com/ca-la/bin/pull/9

Basically if the server is in a state where it can't respond with valid JSON to validate that we're at the correct migration hash, something must be wrong with the server, so we should allow deployments to fix said issue.