### PR TITLE
Add diff log to `release`

### DIFF
--- a/release
+++ b/release
@@ -50,6 +50,15 @@ run() {
   git push origin production
 
   git checkout main
+
+  local recent_tags=$(git for-each-ref --sort=-creatordate --format '%(refname)' refs/tags | head -n 2)
+  local previous_tag=$(echo "$recent_tags" | tail -n 1)
+  local this_tag=$(echo "$recent_tags" | head -n 1)
+
+  if [[ "$previous_tag" != '' && $this_tag != '' ]]; then
+    echo "ℹ️ Changes in this release (please share a changelog with the team):"
+    git log $previous_tag..$this_tag^
+  fi
 }
 
 run "$@"

--- a/release
+++ b/release
@@ -57,7 +57,7 @@ run() {
 
   if [[ "$previous_tag" != '' && $this_tag != '' ]]; then
     echo "ℹ️ Changes in this release (please share a changelog with the team):"
-    git log $previous_tag..$this_tag^
+    git log --pretty=format:'- %ad (%an) %s' --date=short $previous_tag..$this_tag^
   fi
 }
 


### PR DESCRIPTION
Test output from https://github.com/dylanpyle/cala-release-scratchpad :

```
$ npx cala-release minor
gpg: WARNING: unsafe permissions on homedir '/Users/dylan/.gnupg'
From github.com:dylanpyle/cala-release-scratchpad
 * branch            main       -> FETCH_HEAD
Already up to date.
v1.2.0
Enumerating objects: 6, done.
Counting objects: 100% (6/6), done.
Delta compression using up to 8 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 1.04 KiB | 1.04 MiB/s, done.
Total 4 (delta 2), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To github.com:dylanpyle/cala-release-scratchpad.git
   038ab69..9b255ac  main -> main
 * [new tag]         v1.2.0 -> v1.2.0
Switched to and reset branch 'production'
Your branch is ahead of 'origin/production' by 2 commits.
  (use "git push" to publish your local commits)
From github.com:dylanpyle/cala-release-scratchpad
 * branch            production -> FETCH_HEAD
Already up to date.
Already up to date.
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:dylanpyle/cala-release-scratchpad.git
   5f91dd1..9b255ac  production -> production
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
ℹ️ Changes in this release (please share a changelog with the team):
commit 038ab69b7dbfd44946d546a962a4d60dedc81728
Author: Dylan Pyle <me@dylanpyle.com>
Date:   Tue Aug 17 13:37:12 2021 -0400

    new file
```