### PR TITLE
Don't use less to show changes with git log

### DIFF
--- a/release
+++ b/release
@@ -57,7 +57,7 @@ run() {
 
   if [[ "$previous_tag" != '' && $this_tag != '' ]]; then
     echo "ℹ️ Changes in this release (please share a changelog with the team):"
-    git log --pretty=format:'- %ad (%an) %s' --date=short $previous_tag..$this_tag^
+    git --no-pager log --pretty=format:'- %ad (%an) %s' --date=short $previous_tag..$this_tag^
   fi
 }
 


### PR DESCRIPTION
The output of the git log with `less` disappears from the output
when you quit `less`.
And it becomes harder to copy past the output of the release script.

In the latest studio release I was not able to copy past the changes in release:
ctx: https://thisiscala.slack.com/archives/CHM2Z75TQ/p1644513912125439?thread_ts=1644513214.727459&cid=CHM2Z75TQ

```
Your branch is up to date with 'origin/main'.
ℹ️ Changes in this release (please share a changelog with the team):
```


With this change, the output of the git log will just be printed out in the console together with all other output.
Same technic we use in the Studio bin/release script to show the undeployed API commits:
https://github.com/ca-la/studio/blob/4f4c990ce47426a5fad88f1602f9ae595612a312/bin/lib/check-api#L30
