### PR TITLE
Add new line after changes in git log using tformat instead of format

### DIFF
--- a/release
+++ b/release
@@ -51,13 +51,17 @@ run() {
 
   git checkout main
 
-  local recent_tags=$(git for-each-ref --sort=-creatordate --format '%(refname)' refs/tags | head -n 2)
+  local recent_tags=$(git for-each-ref --sort=-creatordate --format '%(refname:lstrip=2)' refs/tags | head -n 2)
   local previous_tag=$(echo "$recent_tags" | tail -n 1)
   local this_tag=$(echo "$recent_tags" | head -n 1)
 
   if [[ "$previous_tag" != '' && $this_tag != '' ]]; then
     echo "ℹ️ Changes in this release (please share a changelog with the team):"
-    git --no-pager log --pretty=format:'- %ad (%an) %s' --date=short $previous_tag..$this_tag^
+    echo
+    echo $(git show-ref -s --abbrev $previous_tag)...$(git show-ref -s --abbrev $this_tag) $this_tag
+    echo
+    git --no-pager log --pretty=tformat:'- %ad (%an) %s' --date=short $previous_tag..$this_tag^
+    echo
   fi
 }
 


### PR DESCRIPTION
Problem: 
Without `tformat` or `echo` after `git log --no-pager` we ended up in a situation when
the last line of `git-log` is joined with the user's shell prompt.
Like this:
```- 2022-02-14 (Scott Trinh) Update our transpiled target platform to ES2017 (#2069)<user-prompt>$>```

## Changes: 
- use `tformat` in the `git log` to make sure the last line of `git log` has a new line symbol.
- Add hash diff with the latest tag for easy copy/paste the release notes from the release output.

## Example:

Before
```
ℹ️ Changes in this release (please share a changelog with the team):
- 2022-02-17 (Andrey Medvedev) Fix shopping cart loop with back button (#2077)
- 2022-02-14 (Aleksandr Adamant) [w-928] Inform user about additional charge when adding editor users (#2070)
- 2022-02-14 (Andrey Medvedev) Update cala/bin with update to the changes output (#2075)
- 2022-02-14 (Scott Trinh) Update our transpiled target platform to ES2017 (#2069)Andreys-laptop:studio mendrew$
```

After
```
ℹ️ Changes in this release (please share a changelog with the team):

9b0ee5999...5fdfdd865 v4.52.0

- 2022-02-17 (Andrey Medvedev) Fix shopping cart loop with back button (#2077)
- 2022-02-14 (Aleksandr Adamant) [w-928] Inform user about additional charge when adding editor users (#2070)
- 2022-02-14 (Andrey Medvedev) Update cala/bin with an update to the output of the change (#2075)
- 2022-02-14 (Scott Trinh) Update our transpiled target platform to ES2017 (#2069)

Andreys-laptop:studio mendrew$
```