### PR TITLE
Fetch origin tags

### DIFF
--- a/release
+++ b/release
@@ -38,6 +38,7 @@ run() {
 
   preauth_pgp_signature
 
+  git fetch origin --tags
   git pull --ff-only origin main
 
   npm version $release_type


### PR DESCRIPTION
We noticed that we are able to create (and attempt to push) tags that are already present on `origin`.